### PR TITLE
LJ-18 Configure Docker for server module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Dockerfile optimizado para proyecto Kotlin Multiplatform - Módulo Server
+# ==================================================================================
+
+# Stage 1: Cache Gradle dependencies
+FROM gradle:latest AS cache
+RUN mkdir -p /home/gradle/cache_home
+ENV GRADLE_USER_HOME=/home/gradle/cache_home
+
+# Copiar archivos de configuración principales del proyecto
+COPY server/build.gradle.kts gradle.properties settings.gradle.kts /home/gradle/app/
+COPY gradle /home/gradle/app/gradle
+
+# Copiar archivos de configuración de módulos específicos
+#COPY shared/build.gradle.kts /home/gradle/app/shared/build.gradle.kts
+COPY server/build.gradle.kts /home/gradle/app/server/build.gradle.kts
+
+# Crear estructura básica de directorios para evitar errores
+RUN mkdir -p /home/gradle/app/server/src/main/kotlin
+
+WORKDIR /home/gradle/app
+
+# Descargar dependencias del proyecto completo
+RUN gradle dependencies --no-daemon -q || true
+
+# Stage 2: Build Application
+FROM gradle:latest AS build
+
+# Copiar cache de dependencias
+COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
+
+# Copiar todo el código fuente del proyecto
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+
+# Construir el fat JAR específicamente para el módulo server
+# Usamos buildFatJar que está configurado en el build.gradle.kts del server
+RUN gradle :server:buildFatJar --no-daemon --info
+
+# Verificar que el JAR se generó correctamente
+RUN ls -la /home/gradle/src/server/build/libs/
+
+# Stage 3: Create the Runtime Image
+FROM amazoncorretto:22 AS runtime
+
+# Exponer puerto 8080
+EXPOSE 8080
+
+# Crear directorio de la aplicación
+RUN mkdir /app
+
+# Copiar el JAR generado desde el módulo server
+COPY --from=build  /home/gradle/src/server/build/libs/lifetime-journal.jar /app/app.jar
+
+# Punto de entrada con configuraciones de JVM optimizadas
+ENTRYPOINT ["java", \
+    "-server", \
+    "-XX:+UnlockExperimentalVMOptions", \
+    "-XX:+UseG1GC", \
+    "-XX:MaxGCPauseMillis=100", \
+    "-XX:+UseStringDeduplication", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", "/app/app.jar"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,15 +5,28 @@ plugins {
 }
 
 group = "com.apptolast.lifetimejournal"
-version = "1.0.0"
+version = "0.1.0"
 application {
     mainClass.set("com.apptolast.lifetimejournal.ApplicationKt")
     applicationDefaultJvmArgs =
         listOf("-Dio.ktor.development=${extra["io.ktor.development"] ?: "false"}")
 }
 
+ktor {
+    fatJar {
+        archiveFileName.set("lifetime-journal.jar")
+    }
+    docker {
+        jreVersion.set(JavaVersion.VERSION_17)
+
+        localImageName.set("lifetime-journal-docker-image")
+        imageTag.set("0.0.1-preview")
+
+    }
+}
+
 dependencies {
-    implementation(projects.shared)
+//    implementation(projects.shared)
     implementation(libs.logback)
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)

--- a/server/src/main/kotlin/com/apptolast/lifetimejournal/Application.kt
+++ b/server/src/main/kotlin/com/apptolast/lifetimejournal/Application.kt
@@ -8,14 +8,14 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 
 fun main() {
-    embeddedServer(Netty, port = SERVER_PORT, host = "0.0.0.0", module = Application::module)
+    embeddedServer(Netty, port = 8080, host = "0.0.0.0", module = Application::module)
         .start(wait = true)
 }
 
 fun Application.module() {
     routing {
         get("/") {
-            call.respondText("Ktor: ${Greeting().greet()}")
+            call.respondText("Ktor hello world!")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,6 @@ dependencyResolutionManagement {
     }
 }
 
-include(":composeApp")
+//include(":composeApp")
 include(":server")
-include(":shared")
+//include(":shared")


### PR DESCRIPTION
- Added a Dockerfile to build and run the server module.
- Updated `server/build.gradle.kts` to configure fat JAR creation with the name `lifetime-journal.jar` and Docker image settings.
- Modified `settings.gradle.kts` to comment out `composeApp` and `shared` modules, focusing the build on the server module.
- Changed the server port to `8080` and updated the root endpoint response in `Application.kt`.
- Adjusted the server module version to `0.1.0`.